### PR TITLE
Fix broken authorization caused by missing env

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -23,6 +23,7 @@ gem 'puma', '~> 4.1'
 gem 'rack-cors'
 gem 'rails', '~> 6.0.3', '>= 6.0.3.2'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'dotenv-rails', '2.7.6'
 
 gem_group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]


### PR DESCRIPTION
To reproduce:
rails _6.0.3.2_ new test-api --api -m boring-bits-rails-api/template.rb

$ rails c
 > ENV["DEVISE_JWT_SECRET_KEY"]
 => nil 

$ rspec 

Failures:
...
  1) Api::UsersController When fetching a user returns 200
     Failure/Error: expect(response.status).to eq(200)
...
12 examples, 3 failures

Failed examples:

rspec ./spec/controllers/users_controller_spec.rb:15 # Api::UsersController When fetching a user returns 200
rspec ./spec/controllers/users_controller_spec.rb:19 # Api::UsersController When fetching a user returns the user
rspec ./spec/controllers/users_controller_spec.rb:33 # Api::UsersController When a user is missing returns 404